### PR TITLE
Perfomance Benchmark + Improvements

### DIFF
--- a/src/Number/Integer.php
+++ b/src/Number/Integer.php
@@ -56,7 +56,10 @@ final class Integer extends NonComplexNumber implements IntegerDivision
     {
         $this->guardDivisorIsNotZero($other);
 
-        return new Integer((int) floor($this->value / $other->value));
+        $newValue = clone $this;
+        $newValue->value = floor($newValue->value / $other->value);
+
+        return $newValue;
     }
 
     /**
@@ -70,8 +73,12 @@ final class Integer extends NonComplexNumber implements IntegerDivision
     {
         $this->guardDivisorIsNotZero($other);
 
-        return new Integer($this->value % $other->value);
+        $newValue = clone $this;
+        $newValue->value %= $other->value;
+
+        return $newValue;
     }
+
     protected function guardConstructionValue($value)
     {
         if (!\is_int($value)) {

--- a/src/Number/NonComplexNumber.php
+++ b/src/Number/NonComplexNumber.php
@@ -70,7 +70,10 @@ abstract class NonComplexNumber implements Number
             throw new \InvalidArgumentException('Only non complex numbers of the same type may be added');
         }
 
-        return new static($this->value + $other->value);
+        $newValue = clone $this;
+        $newValue->value += $other->value;
+
+        return $newValue;
     }
 
     /**
@@ -88,7 +91,10 @@ abstract class NonComplexNumber implements Number
             throw new \InvalidArgumentException('Only non complex numbers of the same type may be subtracted');
         }
 
-        return new static ($this->value - $other->value);
+        $newValue = clone $this;
+        $newValue->value -= $other->value;
+
+        return $newValue;
     }
 
     /**
@@ -106,7 +112,10 @@ abstract class NonComplexNumber implements Number
             throw new \InvalidArgumentException('Only non complex numbers of the same type may be multiplied');
         }
 
-        return new static($this->value * $other->value);
+        $newValue = clone $this;
+        $newValue->value *= $other->value;
+
+        return $newValue;
     }
 
     /**
@@ -122,7 +131,10 @@ abstract class NonComplexNumber implements Number
     {
         $this->guardDivisorIsNotZero($other);
 
-        return new static($this->value / $other->value);
+        $newValue = clone $this;
+        $newValue->value /= $other->value;
+
+        return $newValue;
     }
 
     /**


### PR DESCRIPTION
As promised some time ago in our famous yard, here's my little patch evolved from my little performance experiments with Rasmus' vagrant box.

I've used the following starry eyed benchmark:
```php
<?php
require_once "ValueObjects/vendor/autoload.php";
use Masthowasli\ValueObject\Number\Integer;

$start = microtime(true);

$cycles = 1000000;
for ($repeat = 0; $repeat < $cycles; $repeat++) {
    $i1 = new Integer(7);
    $i2 = new Integer(3);

    $r1 = $i1->add($i2);
    $r2 = $i1->subtract($i2);
    $r3 = $i1->multiply($i2);
    $r4 = $i1->divide($i2);
    $r5 = $i1->remainder($i2);
}

$secs = microtime(true) - $start;
print "$secs\n";
```

Here are the results from my patch with fresh baked interpreters inside `VBox 5.0.14` running on `OSX 10.11.4` driven by a `2012 Core i7 2,6GHz`, the difference from php7 alone is crazy:

![screen shot 2016-04-24 at 14 04 06](https://cloud.githubusercontent.com/assets/8287846/14767526/c3d897c6-0a27-11e6-9bb5-d42abdf3d1c3.png)

The same should also be done for the other Types. 
`grep -r new src/` is your friend ;)
I found a general Issue in the Money Type Hierarchy, but we can discuss this next time on the yard ;)

ps.:
If you want a bad mood, try my benchmark with something like this and compare the results:
```php
for ($repeat = 0; $repeat < $cycles; $repeat++) {
    $int1 = 7;
    $int2 = 3;

    $r1 = $int1 + $int2;
    $r2 = $int1 - $int2;
    $r3 = $int1 * $int2;
    $r4 = $int1 / $int2;
    $r5 = $int1 % $int2;
}
